### PR TITLE
Fix gcc 8 errors

### DIFF
--- a/src/beerocks/cli/beerocks_cli.cpp
+++ b/src/beerocks/cli/beerocks_cli.cpp
@@ -65,8 +65,8 @@ void cli::resetArguments()
     command.clear();
     commandIt        = functionsMap.end();
     commandNumOfArgs = 0;
-    memset(args.intArgs, 0, ARGSNUM);
-    memset(args.floatArgs, 0, ARGSNUM);
+    memset(args.intArgs, 0, sizeof(args.intArgs));
+    memset(args.floatArgs, 0, sizeof(args.intArgs));
     for (int i = 0; i < ARGSNUM; i++) {
         args.stringArgs[i] = "";
     }

--- a/src/beerocks/cli/beerocks_cli.cpp
+++ b/src/beerocks/cli/beerocks_cli.cpp
@@ -66,7 +66,7 @@ void cli::resetArguments()
     commandIt        = functionsMap.end();
     commandNumOfArgs = 0;
     memset(args.intArgs, 0, sizeof(args.intArgs));
-    memset(args.floatArgs, 0, sizeof(args.intArgs));
+    memset(args.floatArgs, 0, sizeof(args.floatArgs));
     for (int i = 0; i < ARGSNUM; i++) {
         args.stringArgs[i] = "";
     }

--- a/src/beerocks/master/db/db.cpp
+++ b/src/beerocks/master/db/db.cpp
@@ -2813,7 +2813,7 @@ bool db::get_node_channel_ext_above_secondary(std::string mac)
     auto n = get_node(mac);
     if (!n) {
         LOG(WARNING) << __FUNCTION__ << " - node " << mac << " does not exist!";
-        return beerocks::BANDWIDTH_MAX;
+        return false;
     }
     return n->channel_ext_above_secondary;
 }

--- a/src/beerocks/master/son_master_thread.cpp
+++ b/src/beerocks/master/son_master_thread.cpp
@@ -1212,8 +1212,9 @@ bool master_thread::handle_cmdu_control_message(
         if (notification == nullptr) {
             LOG(ERROR)
                 << "addClass ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION failed";
-            break;
+            return false;
         }
+        break;
     }
     case beerocks_message::ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE: {
         auto notification =

--- a/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -715,7 +715,6 @@ void optimal_path_task::work()
             }
         }
 
-
         // Check if hostapd has suitable ssid
         auto it = hostap_candidates.begin();
         while (it != hostap_candidates.end()) {

--- a/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -202,6 +202,7 @@ void optimal_path_task::work()
 
         iterator_element_counter = 1; // initialize counter value
         state                    = REQUEST_11K_MEASUREMENTS_BY_BSSID;
+        break;
     }
     case REQUEST_11K_MEASUREMENTS_BY_BSSID: {
 
@@ -620,6 +621,7 @@ void optimal_path_task::work()
         }
 
         state = REQUEST_CROSS_RSSI_MEASUREMENTS;
+        break;
     }
     case REQUEST_CROSS_RSSI_MEASUREMENTS: {
         if (!assert_original_parent()) {


### PR DESCRIPTION
Fix the errors found by GCC8 -Werror.

The switch fallthrough fixes need careful review and testing (which I'm not able to do) since they really change behaviour.