### PR TITLE
build: fix fallthrough annotation break

### DIFF
--- a/src/beerocks/master/db/network_map.cpp
+++ b/src/beerocks/master/db/network_map.cpp
@@ -759,7 +759,7 @@ std::ptrdiff_t network_map::fill_bml_node_statistics(db &database, std::shared_p
             break;
         }
     }
-        [[fallthrough]];
+        FALLTHROUGH;
     case beerocks::TYPE_CLIENT: {
         //LOG(DEBUG) << "fill TYPE_CLIENT";
 


### PR DESCRIPTION
-Elaborate:
fixing the bug inserted in this commit:
73403dc

the [fallthrough] annotation is only supported in new compilers, so this
fix is recplacing it with a macro based on the compiler version.

Signed-off-by: Lior Amram <lior.amram@intel.com>