### PR TITLE
logging: Add runtime syslog support configuration

### DIFF
--- a/config/beerocks_controller.conf
+++ b/config/beerocks_controller.conf
@@ -77,3 +77,4 @@ log_path=/tmp/beerocks/logs/
 log_global_levels=error,info,warning,fatal,trace,debug
 log_global_syslog_levels=error,info,warning,fatal,trace,debug
 log_global_size=1000000
+log_syslog_enabled=false


### PR DESCRIPTION
Elaborate:
-Add syslog configuration to allow turning syslog writing on/off in
runtime.
-Based on the changes in these PRs:
 prplfoundation/prplMesh-framework#13
 prplfoundation/prplMesh-common#11

Test:
build + testing logs on ubuntu, ugw and rdkb

Signed-off-by: Lior Amram <lior.amram@intel.com>