### PR TITLE
conf: update beerocks tmp path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,13 @@ message(STATUS "Beerocks Build Type: ${CMAKE_BUILD_TYPE}")
 # Platform specific flags
 if (TARGET_PLATFORM STREQUAL "ugw")
     add_definitions(-DBEEROCKS_UGW)
+    set(BEEROCKS_TMP_PATH "/tmp/beerocks")
 elseif(TARGET_PLATFORM STREQUAL "rdkb")
     add_definitions(-DBEEROCKS_RDKB)
+    set(BEEROCKS_TMP_PATH "/tmp/beerocks")
     set(CMAKE_SKIP_RPATH TRUE)
+elseif (TARGET_PLATFORM STREQUAL "linux")
+    set(BEEROCKS_TMP_PATH "/tmp/$ENV{USER}/beerocks")
 endif()
 
 # Use beerocks intel ip patent

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -2,9 +2,13 @@ configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/beerocks_controller_version.in"
         "${CMAKE_CURRENT_BINARY_DIR}/beerocks_controller_version"
         )
+configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/beerocks_controller.conf.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/beerocks_controller.conf"
+        )
 
 set(confs 
-    beerocks_controller.conf
+    ${CMAKE_CURRENT_BINARY_DIR}/beerocks_controller.conf
     ${CMAKE_CURRENT_BINARY_DIR}/beerocks_controller_version)
 
 install(FILES ${confs} DESTINATION config)

--- a/config/beerocks_controller.conf.in
+++ b/config/beerocks_controller.conf.in
@@ -6,7 +6,7 @@
 #############################################################################
 
 [controller]
-temp_path=/tmp/beerocks/
+temp_path=@BEEROCKS_TMP_PATH@
 
 # Features:
 #   DFS reentry feature:
@@ -73,7 +73,7 @@ fail_safe_5G_bw=80
 fail_safe_5G_vht_frequency=5210
 
 [log]
-log_path=/tmp/beerocks/logs/
+log_path=@BEEROCKS_TMP_PATH@/logs
 log_global_levels=error,info,warning,fatal,trace,debug
 log_global_syslog_levels=error,info,warning,fatal,trace,debug
 log_global_size=1000000


### PR DESCRIPTION
- Update beerocks tmp path to use CMAKE variable
- In Linux target, use /tmp/$USER/ to allow multiple users run on the
same machine
- Add beerocks_controller.conf.in which generates
beerocks_controller.conf based on CMAKE variables

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>